### PR TITLE
replaced xorg-server-utils with xorg-apps…

### DIFF
--- a/asinstaller/install.py
+++ b/asinstaller/install.py
@@ -337,7 +337,7 @@ def video_utils():
 
             try:
                 sel = menus.gpus[gpu]
-                system('pacman -S xorg-server xorg-server-utils xorg-xinit ' \
+                system('pacman -S xorg-server xorg-apps xorg-xinit ' \
                     + 'xterm {0} --noconfirm'''.format(sel), True)
                 break
             except KeyError:


### PR DESCRIPTION
xorg-server-utils is removed from mainstream arch, most of the packages provided by xorg-server-utils is moved to xorg-apps.